### PR TITLE
Feature/boot option viewer

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "name": "windows-gcc-x64",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "compilerPath": "C:/msys64/ucrt64/bin/gcc.exe",
+      "cStandard": "${default}",
+      "cppStandard": "${default}",
+      "intelliSenseMode": "windows-gcc-x64",
+      "compilerArgs": [
+        ""
+      ]
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C/C++ Runner: Debug Session",
+      "type": "cppdbg",
+      "request": "launch",
+      "args": [],
+      "stopAtEntry": false,
+      "externalConsole": true,
+      "cwd": "//wsl.localhost/Ubuntu/home/jordanform/uefi-ws/pkgs/MiUPkg/Application/MiU",
+      "program": "//wsl.localhost/Ubuntu/home/jordanform/uefi-ws/pkgs/MiUPkg/Application/MiU/build/Debug/outDebug",
+      "MIMode": "gdb",
+      "miDebuggerPath": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,59 @@
+{
+  "C_Cpp_Runner.cCompilerPath": "gcc",
+  "C_Cpp_Runner.cppCompilerPath": "g++",
+  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/VR_NR/Community/VC/Auxiliary/Build/vcvarsall.bat",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
+}

--- a/Application/MiU/MiU.c
+++ b/Application/MiU/MiU.c
@@ -13,6 +13,7 @@
 #include "Variables.h"
 #include "IoSpace.h"
 #include "ShowMemoryMap.h"
+#include "ShowBootOption.h"
 
 // Globals variable for input handling
 EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *mInputEx = NULL; 
@@ -146,8 +147,10 @@ ShowHelpPopup(VOID)
     Print(L"F5 : Read I/O Space");
     ConOut->SetCursorPosition(ConOut, PopupLeft + 4, PopupTop + 8);
     Print(L"F6 : Show Memory Map");
+    ConOut->SetCursorPosition(ConOut, PopupLeft + 4, PopupTop + 9);
+    Print(L"F7 : Show Boot Options");
     
-    ConOut->SetCursorPosition(ConOut, PopupLeft + 4, PopupTop + 10);
+    ConOut->SetCursorPosition(ConOut, PopupLeft + 4, PopupTop + 11);
     Print(L"ENTER : View PCI Config Space");
     ConOut->SetCursorPosition(ConOut, PopupLeft + 4, PopupTop + 11);
     Print(L"ESC   : Quit");
@@ -230,6 +233,14 @@ MainLoop (VOID) {
 
       case SCAN_F6:
         ShowMemoryMap();
+        Print(L"\nPress any key to return...");
+        gBS->WaitForEvent(1, &mInputEx->WaitForKeyEx, NULL);
+        mInputEx->ReadKeyStrokeEx(mInputEx, &KeyData);
+        NeedRedraw = TRUE;
+        break;
+
+      case SCAN_F7:
+        ShowBootOptions();
         Print(L"\nPress any key to return...");
         gBS->WaitForEvent(1, &mInputEx->WaitForKeyEx, NULL);
         mInputEx->ReadKeyStrokeEx(mInputEx, &KeyData);

--- a/Application/MiU/MiU.inf
+++ b/Application/MiU/MiU.inf
@@ -30,6 +30,8 @@
   FileHelper.h
   ShowMemoryMap.c
   ShowMemoryMap.h
+  ShowBootOption.c
+  ShowBootOption.h
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -45,6 +47,7 @@
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
   IoLib
+  DevicePathLib
 
 [Protocols]
   gEfiPciIoProtocolGuid ## CONSUMES

--- a/Application/MiU/ShowBootOption.c
+++ b/Application/MiU/ShowBootOption.c
@@ -1,0 +1,269 @@
+#include "ShowBootOption.h"
+#include <Library/PrintLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DevicePathLib.h>
+#include <Protocol/LoadedImage.h>
+#include <Protocol/DevicePath.h>
+#include "FileHelper.h"
+
+/**
+  Display all Boot#### variables in the system.
+
+  @retval EFI_SUCCESS     Successfully displayed all boot options.
+  @retval Others          Failed to get or display boot options.
+**/
+typedef struct {
+  CHAR16    Name[16];       // Boot#### format
+  CHAR16    Description[256];
+  UINT32    Attributes;
+  UINTN     DataSize;
+  UINT8     *Data;
+} BOOT_OPTION_ENTRY;
+
+STATIC
+VOID
+ShowBootOptionData(
+  IN BOOT_OPTION_ENTRY  *BootEntry
+  )
+{
+  EFI_INPUT_KEY Key;
+  UINTN         BytesPerLine = 16;
+  UINTN         Lines;
+  UINTN         Cursor = 0;
+  BOOLEAN       ExitView = FALSE;
+
+  while (!ExitView) {
+    // Clear and redraw header
+    gST->ConOut->ClearScreen(gST->ConOut);
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+
+    // Top lines: Name and Description
+    Print(L"%s\n", BootEntry->Name);
+    Print(L"%s\n", BootEntry->Description);
+    Print(L"Size: 0x%X\n", BootEntry->DataSize);
+
+    // Print hex dump with headers
+    Lines = (BootEntry->DataSize + BytesPerLine - 1) / BytesPerLine;
+
+    // Column headers
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_RED, EFI_BLUE));
+    Print(L"    ");
+    for (UINTN col = 0; col < BytesPerLine; col++) {
+      if (col == (Cursor % BytesPerLine)) {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+      } else {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_RED, EFI_BLUE));
+      }
+      Print(L"%02x ", col);
+    }
+    Print(L"\n");
+
+    // Data rows
+    for (UINTN row = 0; row < Lines; row++) {
+      UINTN base = row * BytesPerLine;
+
+      if (row == (Cursor / BytesPerLine)) {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+      } else {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_RED, EFI_BLUE));
+      }
+      Print(L"%02x: ", base);
+
+      for (UINTN col = 0; col < BytesPerLine; col++) {
+        UINTN idx = base + col;
+        if (idx >= BootEntry->DataSize) {
+          Print(L"   ");
+        } else {
+          if (idx == Cursor) {
+            gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_GREEN));
+          } else {
+            gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLUE));
+          }
+          Print(L"%02x ", BootEntry->Data[idx]);
+        }
+      }
+      Print(L"\n");
+    }
+
+    // Bottom: prompt
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+    Print(L"\nUse Up/Down/Left/Right arrows to move, ESC to return\n");
+
+    // Wait for key
+    gBS->WaitForEvent(1, &gST->ConIn->WaitForKey, NULL);
+    gST->ConIn->ReadKeyStroke(gST->ConIn, &Key);
+
+    // Navigation
+    if (Key.UnicodeChar == CHAR_NULL) {
+      switch (Key.ScanCode) {
+        case SCAN_LEFT:
+          if (Cursor > 0) Cursor--;
+          break;
+        case SCAN_RIGHT:
+          if (Cursor + 1 < BootEntry->DataSize) Cursor++;
+          break;
+        case SCAN_UP:
+          if (Cursor >= BytesPerLine) Cursor -= BytesPerLine;
+          break;
+        case SCAN_DOWN:
+          if (Cursor + BytesPerLine < BootEntry->DataSize) Cursor += BytesPerLine;
+          break;
+        case SCAN_ESC:
+          ExitView = TRUE;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_LIGHTGRAY, EFI_BLUE));
+}
+
+EFI_STATUS
+EFIAPI
+ShowBootOptions (
+  VOID
+  )
+{
+  EFI_STATUS         Status;
+  UINT16             BootOrder[100];
+  UINTN             BootOrderSize;
+  BOOT_OPTION_ENTRY *BootList;
+  UINTN             BootCount = 0;
+  EFI_INPUT_KEY     Key;
+  UINTN             CurrentSelection = 0;
+  BOOLEAN           ExitMenu = FALSE;
+
+  // Get the BootOrder variable
+  BootOrderSize = sizeof(BootOrder);
+  Status = gRT->GetVariable(
+                  L"BootOrder",
+                  &gEfiGlobalVariableGuid,
+                  NULL,
+                  &BootOrderSize,
+                  BootOrder
+                  );
+
+  if (EFI_ERROR(Status)) {
+    Print(L"Failed to get BootOrder variable: %r\n", Status);
+    return Status;
+  }
+
+  // Allocate array for boot options
+  UINTN MaxBootOptions = BootOrderSize / sizeof(UINT16);
+  BootList = AllocateZeroPool(sizeof(BOOT_OPTION_ENTRY) * MaxBootOptions);
+  if (BootList == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Read all boot options
+  for (UINTN i = 0; i < MaxBootOptions; i++) {
+    CHAR16 BootVarName[16];
+    UnicodeSPrint(BootVarName, sizeof(BootVarName), L"Boot%04x", BootOrder[i]);
+    
+    // Copy the name
+    StrCpyS(BootList[BootCount].Name, 16, BootVarName);
+    
+    // Get the boot option data
+    UINTN VarSize = 0;
+    Status = gRT->GetVariable(
+                    BootVarName,
+                    &gEfiGlobalVariableGuid,
+                    &BootList[BootCount].Attributes,
+                    &VarSize,
+                    NULL
+                    );
+
+    if (Status == EFI_BUFFER_TOO_SMALL && VarSize > 0) {
+      BootList[BootCount].Data = AllocatePool(VarSize);
+      BootList[BootCount].DataSize = VarSize;
+      
+      if (BootList[BootCount].Data != NULL) {
+        Status = gRT->GetVariable(
+                      BootVarName,
+                      &gEfiGlobalVariableGuid,
+                      &BootList[BootCount].Attributes,
+                      &VarSize,
+                      BootList[BootCount].Data
+                      );
+
+        if (!EFI_ERROR(Status)) {
+          // Copy description (starts after Attributes(4) + FilePathListLength(2))
+          CHAR16 *Desc = (CHAR16 *)(BootList[BootCount].Data + 6);
+          StrCpyS(BootList[BootCount].Description, 256, Desc);
+          BootCount++;
+        } else {
+          FreePool(BootList[BootCount].Data);
+        }
+      }
+    }
+  }
+
+  // Main menu loop
+  while (!ExitMenu) {
+    // Clear screen and set colors
+    gST->ConOut->ClearScreen(gST->ConOut);
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_RED));
+    Print(L"=== Boot Options ===                \n\n");
+
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+
+    // Display all boot options
+    for (UINTN i = 0; i < BootCount; i++) {
+      if (i == CurrentSelection) {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_YELLOW, EFI_GREEN));
+      } else {
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+      }
+      Print(L"%s: %s\n", BootList[i].Name, BootList[i].Description);
+    }
+
+    // Reset color to blue background for the instruction text
+    gST->ConOut->SetAttribute(gST->ConOut, EFI_TEXT_ATTR(EFI_WHITE, EFI_BLUE));
+    Print(L"\nUse Up/Down to select, Enter to view details, ESC to exit\n");
+
+    // Wait for key
+    gBS->WaitForEvent(1, &gST->ConIn->WaitForKey, NULL);
+    gST->ConIn->ReadKeyStroke(gST->ConIn, &Key);
+
+    if (Key.UnicodeChar == CHAR_CARRIAGE_RETURN) {
+      // Show details of selected boot option
+      ShowBootOptionData(&BootList[CurrentSelection]);
+    } else if (Key.UnicodeChar == CHAR_NULL) {
+      switch (Key.ScanCode) {
+        case SCAN_UP:
+          if (CurrentSelection > 0) {
+            CurrentSelection--;
+          } else {
+            // Wrap to bottom
+            CurrentSelection = BootCount - 1;
+          }
+          break;
+        case SCAN_DOWN:
+          if (CurrentSelection + 1 < BootCount) {
+            CurrentSelection++;
+          } else {
+            // Wrap to top
+            CurrentSelection = 0;
+          }
+          break;
+        case SCAN_ESC:
+          ExitMenu = TRUE;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  // Cleanup
+  for (UINTN i = 0; i < BootCount; i++) {
+    if (BootList[i].Data != NULL) {
+      FreePool(BootList[i].Data);
+    }
+  }
+  FreePool(BootList);
+
+  return EFI_SUCCESS;
+}

--- a/Application/MiU/ShowBootOption.h
+++ b/Application/MiU/ShowBootOption.h
@@ -1,0 +1,22 @@
+#ifndef __SHOW_BOOT_OPTION_H__
+#define __SHOW_BOOT_OPTION_H__
+
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+/**
+  Display all Boot#### variables in the system.
+
+  @retval EFI_SUCCESS     Successfully displayed all boot options.
+  @retval Others          Failed to get or display boot options.
+**/
+EFI_STATUS
+EFIAPI
+ShowBootOptions (
+  VOID
+  );
+
+#endif

--- a/Application/MiU/Variables.c
+++ b/Application/MiU/Variables.c
@@ -309,7 +309,7 @@ ReadAllVariables(VOID)
 
       // highlight selected line in green
       if (i == CurrSel) {
-        gST->ConOut->SetAttribute(gST->ConOut, EFI_BACKGROUND_GREEN | EFI_BLUE);
+        gST->ConOut->SetAttribute(gST->ConOut, EFI_BACKGROUND_GREEN | EFI_YELLOW);
       } else {
         gST->ConOut->SetAttribute(gST->ConOut, EFI_BACKGROUND_BLUE  | EFI_WHITE);
       }


### PR DESCRIPTION
# Boot Options Viewer Enhancement

## Overview
This PR adds a new feature to display and navigate UEFI boot options using the F7 key in the helper menu. The implementation provides a user-friendly interface similar to the existing variable viewer, allowing users to browse and inspect boot option details.

## Features
- Added new interactive boot options viewer accessible via F7
- Implements two-level navigation system:
  * Main level: List of all Boot#### entries with descriptions
  * Detail level: Hex viewer for selected boot option's raw data
- Consistent UI with existing features:
  * Blue background with white/gray text
  * Green highlight for selected items
  * Intuitive navigation controls

## Technical Details
- Uses UEFI Runtime Services to read Boot#### variables
- Implements circular navigation (wrap-around) when reaching list boundaries
- Properly handles memory allocation/deallocation for variable data
- Maintains consistent color scheme across the interface
- Parses boot option data structure to display readable descriptions

## Testing
Tested scenarios:
- Navigation through boot options list (Up/Down with wraparound)
- Viewing detailed hex data of boot options (Enter)
- Color consistency when navigating
- Memory management for various boot option sizes
- ESC key functionality for both levels

## Screenshots
<img width="809" height="352" alt="image" src="https://github.com/user-attachments/assets/77c83b35-b78c-4204-b55e-4ce9464687bc" />
<img width="853" height="488" alt="image" src="https://github.com/user-attachments/assets/7affe1a4-57f1-4441-aa66-838ff24ab039" />

## Related
Part of the MiU UEFI tool enhancement project